### PR TITLE
Allow custom item metadata

### DIFF
--- a/projects/ngx-time-scheduler/src/lib/ngx-time-scheduler.model.ts
+++ b/projects/ngx-time-scheduler/src/lib/ngx-time-scheduler.model.ts
@@ -18,6 +18,7 @@ export class Item {
   classes: string;
   sectionID: number;
   tooltip?: string;
+  metadata?: any;
 }
 
 export class Section {


### PR DESCRIPTION
Store some data on the item itself, like current section (from-to) and other data like JSON object comming from api request to be used on the drop event